### PR TITLE
Add verify-ssl-certificate option

### DIFF
--- a/config.example.php
+++ b/config.example.php
@@ -47,6 +47,9 @@ $config = [
             'expire' => [
                 'meta' => 86400,
                 'data' => 2592000
+            ],
+            'http-request' => [
+                'verify-ssl-certificate': true
             ]
         ],
         'github' => [

--- a/core/Components/Helper.php
+++ b/core/Components/Helper.php
@@ -5,6 +5,7 @@ namespace Core\Components;
 
 use Core\Contracts\CacheAbstract;
 use Core\Contracts\Responsible;
+use Core\Components\Config;
 use Core\Items\DataItem;
 use GuzzleHttp\Client;
 use GuzzleHttp\Exception\GuzzleException;
@@ -26,7 +27,8 @@ class Helper
                 'headers' => [
                     'User-Agent' => 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/78.0.3872.0 Safari/537.36 avatar-cache/' . Config::version(),
                     'Accept' => 'image/*,*/*'
-                ]
+                ],
+                'verify' => Config::getConfig()['service']['http-request']['verify-ssl-certificate']
             ]);
         } catch (GuzzleException $e) {
             throw $e;


### PR DESCRIPTION
On some machine, the ssl certificate verify operation may fail.

So I add this to pass GuzzleHttp's verify option to the configuration file.